### PR TITLE
equal padding for docs-wrapper

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,5 @@
+import "../globals/overrides.css";
+
 // https://storybook.js.org/docs/react/writing-stories/parameters#global-parameters
 export const parameters = {
   // https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,4 @@
-import "../globals/overrides.css";
+import "../styles/globals.css";
 
 // https://storybook.js.org/docs/react/writing-stories/parameters#global-parameters
 export const parameters = {

--- a/packages/auth/src/components/AuthProvider/AuthProviderStory.tsx
+++ b/packages/auth/src/components/AuthProvider/AuthProviderStory.tsx
@@ -6,11 +6,6 @@ import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 export default function AuthProviderStory() {
   return (
     <Box
-      px={{
-        base: 4,
-        md: 8,
-        lg: 12,
-      }}
       sx={{
         '& p': {
           color: 'neutrals.800',

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,3 @@
+.sbdocs-wrapper {
+  padding: 2rem !important;
+}


### PR DESCRIPTION
equal padding of `2rem` for `docs-wrapper`

<img width="752" alt="image" src="https://user-images.githubusercontent.com/86353187/204249937-6b1e140c-5737-4175-a0b3-a2c3f855095b.png">

`padding-top` and `padding-bottom` was previously set to `4rem`
