### PR TITLE
add empty and loading state to table and fix relay pagination legend …

### DIFF
--- a/packages/pagination/src/RelayPagination.tsx
+++ b/packages/pagination/src/RelayPagination.tsx
@@ -33,8 +33,8 @@ export default function RelayPagination({
   const styles = useStyles("relay");
 
   const remainder = count % pageSize;
-  const indexFrom = (page - 1) * pageSize + 1;
-  const indexTo = page * pageSize;
+  const indexFrom = count <= 0 ? 0 : (page - 1) * pageSize + 1;
+  const indexTo = count <= 0 ? 0 : page * pageSize;
 
   const hasPrev = page > 1;
   const hasNext = page * pageSize < count;

--- a/packages/table/src/Table.stories.tsx
+++ b/packages/table/src/Table.stories.tsx
@@ -64,6 +64,7 @@ Default.args = {
       </chakra.button>
     </Flex>
   ),
+  isLoading: false,
   columns: [
     {
       label: "Name",

--- a/packages/table/src/hooks.ts
+++ b/packages/table/src/hooks.ts
@@ -1,0 +1,57 @@
+import { SystemStyleObject } from "@chakra-ui/react";
+
+export const tableContainerStyles: SystemStyleObject = {
+  "&::-webkit-scrollbar": {
+    width: "12px",
+  },
+  "&::-webkit-scrollbar-thumb": {
+    rounded: "full",
+    bgColor: "neutrals.300",
+    border: "6px solid",
+    borderColor: "transparent",
+    backgroundClip: "padding-box",
+  },
+  "&::-webkit-scrollbar-track-piece": {
+    rounded: "full",
+    bgColor: "neutrals.100",
+    border: "6px solid",
+    borderColor: "transparent",
+    backgroundClip: "padding-box",
+  },
+  "&::-webkit-scrollbar-track": {
+    bgColor: "transparent",
+  },
+};
+
+export const tableStyles: SystemStyleObject = {
+  thead: {
+    bgColor: "#F9FAFB",
+  },
+  "th, td": {
+    borderColor: "#EAECF0",
+  },
+  th: {
+    paddingY: "12px",
+    paddingX: "24px",
+    textTransform: "unset",
+    color: "#667085",
+    fontSize: "12px",
+    lineHeight: "18px",
+    fontWeight: "medium",
+  },
+  td: {
+    paddingY: "16px",
+    paddingX: "24px",
+    color: "#7A7A7A",
+    fontSize: "14px",
+    lineHeight: "20px",
+    letterSpacing: "0.02em",
+  },
+  tr: {
+    _last: {
+      td: {
+        borderBottom: "none",
+      },
+    },
+  },
+};


### PR DESCRIPTION
- fixed issue in `RelayPagination` where legend says `1-0` instead of `0-0` when `count` is set to `0`
- add option `Table.isLoading` and `Table.renderLoader`
- display `No record found` when `Table.items` is empty and `Table.isLoading` is `false`