### PR TITLE
more friendly test ids in tabs

### DIFF
--- a/packages/tab/src/ButtonTabs.tsx
+++ b/packages/tab/src/ButtonTabs.tsx
@@ -91,9 +91,9 @@ export default function ButtonTabs({
   );
 
   const panels = (
-    <TabPanels data-testid="hds.button-tabs.panels">
+    <TabPanels padding={0} data-testid="hds.button-tabs.panels">
       {items.map(({ render: Component }) => (
-        <TabPanel key={uuid()} data-testid="hds.button-tabs.panels.panel">
+        <TabPanel key={uuid()} padding={0} data-testid="hds.button-tabs.panels.panel">
           <Component />
         </TabPanel>
       ))}

--- a/packages/tab/src/ButtonTabs.tsx
+++ b/packages/tab/src/ButtonTabs.tsx
@@ -67,21 +67,23 @@ export default function ButtonTabs({
       sx={styles.tablist}
       {...(placement === 'end' && { ml: 'auto' })}
       {...(placement === 'start' && { mr: 'auto' })}
-      data-testid="hds.tab-button.list"
+      data-testid="hds.button-tabs.list"
     >
       {items?.map(({ label }, idx) => {
         return (
           <Tab
             key={uuid()}
             _selected={_selected}
-            data-testid="hds.tab-button.tab"
+            data-testid="hds.button-tabs.tab"
             padding={'10px 16px'}
             sx={size === 'md' ? styles.tab : undefined}
             maxW={'auto'}
             width={fitToBox ? '100%' : 'auto'}
             borderRight={idx === items.length - 1 ? 'none' : '1px solid #D0D5DD'}
           >
-            <Text size="label-xs-default">{label}</Text>
+            <Text size="label-xs-default" data-testid="hds.button-tabs.tab.label">
+              {label}
+            </Text>
           </Tab>
         );
       })}
@@ -89,9 +91,9 @@ export default function ButtonTabs({
   );
 
   const panels = (
-    <TabPanels data-testid="hds.tab-button.tab.panel">
+    <TabPanels data-testid="hds.button-tabs.panels">
       {items.map(({ render: Component }) => (
-        <TabPanel key={uuid()}>
+        <TabPanel key={uuid()} data-testid="hds.button-tabs.panels.panel">
           <Component />
         </TabPanel>
       ))}
@@ -106,7 +108,7 @@ export default function ButtonTabs({
       align={placement}
       index={selectedIndex}
       onChange={setSelectedIndex}
-      data-testid="hds.tab-button.tabs"
+      data-testid="hds.button-tabs.tabs"
       {...(!preferMounted && {
         isLazy: true,
         lazyBehavior: 'unmount',

--- a/packages/tab/src/Tabs.tsx
+++ b/packages/tab/src/Tabs.tsx
@@ -116,14 +116,9 @@ export default function HdsTabs({
         ))}
       </TabList>
 
-      <TabPanels
-        width="auto"
-        height="auto"
-        paddingTop={modifiedOrientation === 'horizontal' ? 8 : 0}
-        data-testid="hds.tabs.panels"
-      >
+      <TabPanels width="auto" height="auto" padding={0} data-testid="hds.tabs.panels">
         {items?.map(({ render: Component }) => (
-          <TabPanel key={uuid()} data-testid="hds.tabs.panels.panel">
+          <TabPanel key={uuid()} padding={0} data-testid="hds.tabs.panels.panel">
             <Component />
           </TabPanel>
         ))}

--- a/packages/tab/src/Tabs.tsx
+++ b/packages/tab/src/Tabs.tsx
@@ -93,7 +93,7 @@ export default function HdsTabs({
         flexDir={modifiedOrientation === 'vertical' ? 'column' : 'row'}
         placeContent={placementToPlaceContent(placement)}
         sx={styles.tablist}
-        data-testid="hds.tab.list"
+        data-testid="hds.tabs.tablist"
       >
         {items?.map(({ label, badgeCount }, ...args) => (
           <Tab
@@ -103,10 +103,10 @@ export default function HdsTabs({
             justifyContent={modifiedOrientation === 'vertical' ? 'flex-start' : 'center'}
             transition="colors 300ms ease-in-out"
             sx={styles.tab}
-            data-testid="hds.tab"
+            data-testid="hds.tabs.tab"
           >
             <Flex align="center" gap={2}>
-              <Text size="label-xs-default" whiteSpace="nowrap" data-testid="hds.tab.label">
+              <Text size="label-xs-default" whiteSpace="nowrap" data-testid="hds.tabs.tab.label">
                 {label}
               </Text>
 
@@ -120,10 +120,10 @@ export default function HdsTabs({
         width="auto"
         height="auto"
         paddingTop={modifiedOrientation === 'horizontal' ? 8 : 0}
-        data-testid="hds.tab.panels"
+        data-testid="hds.tabs.panels"
       >
         {items?.map(({ render: Component }) => (
-          <TabPanel key={uuid()} data-testid="hds.tab.panels">
+          <TabPanel key={uuid()} data-testid="hds.tabs.panels.panel">
             <Component />
           </TabPanel>
         ))}
@@ -165,7 +165,7 @@ function Badge({ count, isSelected }: BadgeProps) {
       })}
       transition="colors 300ms ease-in-out"
     >
-      <Text size="label-xs-default" color="inherit" data-testid="hds.tab.badge">
+      <Text size="label-xs-default" color="inherit" data-testid="hds.tabs.tab.badge">
         {count}
       </Text>
     </Flex>

--- a/packages/tab/src/__snapshots__/ButtonTabs.spec.tsx.snap
+++ b/packages/tab/src/__snapshots__/ButtonTabs.spec.tsx.snap
@@ -71,12 +71,12 @@ exports[`Snapshot (ButtonTabs) Should match snapshot 1`] = `
     </button>
   </div>
   <div
-    className="chakra-tabs__tab-panels css-8atqhb"
+    className="chakra-tabs__tab-panels css-7m8sgd"
     data-testid="hds.button-tabs.panels"
   >
     <div
       aria-labelledby="tabs-:r0:--tab-0"
-      className="chakra-tabs__tab-panel css-sjt5nk"
+      className="chakra-tabs__tab-panel css-47dblg"
       data-testid="hds.button-tabs.panels.panel"
       hidden={false}
       id="tabs-:r0:--tabpanel-0"
@@ -89,7 +89,7 @@ exports[`Snapshot (ButtonTabs) Should match snapshot 1`] = `
     </div>
     <div
       aria-labelledby="tabs-:r0:--tab-1"
-      className="chakra-tabs__tab-panel css-sjt5nk"
+      className="chakra-tabs__tab-panel css-47dblg"
       data-testid="hds.button-tabs.panels.panel"
       hidden={true}
       id="tabs-:r0:--tabpanel-1"
@@ -98,7 +98,7 @@ exports[`Snapshot (ButtonTabs) Should match snapshot 1`] = `
     />
     <div
       aria-labelledby="tabs-:r0:--tab-2"
-      className="chakra-tabs__tab-panel css-sjt5nk"
+      className="chakra-tabs__tab-panel css-47dblg"
       data-testid="hds.button-tabs.panels.panel"
       hidden={true}
       id="tabs-:r0:--tabpanel-2"

--- a/packages/tab/src/__snapshots__/ButtonTabs.spec.tsx.snap
+++ b/packages/tab/src/__snapshots__/ButtonTabs.spec.tsx.snap
@@ -3,12 +3,12 @@
 exports[`Snapshot (ButtonTabs) Should match snapshot 1`] = `
 <div
   className="chakra-tabs css-1rwh58z"
-  data-testid="hds.tab-button.tabs"
+  data-testid="hds.button-tabs.tabs"
 >
   <div
     aria-orientation="horizontal"
     className="chakra-tabs__tablist css-lvouy5"
-    data-testid="hds.tab-button.list"
+    data-testid="hds.button-tabs.list"
     onKeyDown={[Function]}
     role="tablist"
   >
@@ -16,7 +16,7 @@ exports[`Snapshot (ButtonTabs) Should match snapshot 1`] = `
       aria-controls="tabs-:r0:--tabpanel--1"
       aria-selected={false}
       className="chakra-tabs__tab css-1tpbcy4"
-      data-testid="hds.tab-button.tab"
+      data-testid="hds.button-tabs.tab"
       id="tabs-:r0:--tab--1"
       onClick={[Function]}
       onFocus={[Function]}
@@ -26,6 +26,7 @@ exports[`Snapshot (ButtonTabs) Should match snapshot 1`] = `
     >
       <p
         className="chakra-text css-0"
+        data-testid="hds.button-tabs.tab.label"
       >
         One
       </p>
@@ -34,7 +35,7 @@ exports[`Snapshot (ButtonTabs) Should match snapshot 1`] = `
       aria-controls="tabs-:r0:--tabpanel--1"
       aria-selected={false}
       className="chakra-tabs__tab css-1tpbcy4"
-      data-testid="hds.tab-button.tab"
+      data-testid="hds.button-tabs.tab"
       id="tabs-:r0:--tab--1"
       onClick={[Function]}
       onFocus={[Function]}
@@ -44,6 +45,7 @@ exports[`Snapshot (ButtonTabs) Should match snapshot 1`] = `
     >
       <p
         className="chakra-text css-0"
+        data-testid="hds.button-tabs.tab.label"
       >
         Two
       </p>
@@ -52,7 +54,7 @@ exports[`Snapshot (ButtonTabs) Should match snapshot 1`] = `
       aria-controls="tabs-:r0:--tabpanel--1"
       aria-selected={false}
       className="chakra-tabs__tab css-uh1hvz"
-      data-testid="hds.tab-button.tab"
+      data-testid="hds.button-tabs.tab"
       id="tabs-:r0:--tab--1"
       onClick={[Function]}
       onFocus={[Function]}
@@ -62,6 +64,7 @@ exports[`Snapshot (ButtonTabs) Should match snapshot 1`] = `
     >
       <p
         className="chakra-text css-0"
+        data-testid="hds.button-tabs.tab.label"
       >
         Three
       </p>
@@ -69,11 +72,12 @@ exports[`Snapshot (ButtonTabs) Should match snapshot 1`] = `
   </div>
   <div
     className="chakra-tabs__tab-panels css-8atqhb"
-    data-testid="hds.tab-button.tab.panel"
+    data-testid="hds.button-tabs.panels"
   >
     <div
       aria-labelledby="tabs-:r0:--tab-0"
       className="chakra-tabs__tab-panel css-sjt5nk"
+      data-testid="hds.button-tabs.panels.panel"
       hidden={false}
       id="tabs-:r0:--tabpanel-0"
       role="tabpanel"
@@ -86,6 +90,7 @@ exports[`Snapshot (ButtonTabs) Should match snapshot 1`] = `
     <div
       aria-labelledby="tabs-:r0:--tab-1"
       className="chakra-tabs__tab-panel css-sjt5nk"
+      data-testid="hds.button-tabs.panels.panel"
       hidden={true}
       id="tabs-:r0:--tabpanel-1"
       role="tabpanel"
@@ -94,6 +99,7 @@ exports[`Snapshot (ButtonTabs) Should match snapshot 1`] = `
     <div
       aria-labelledby="tabs-:r0:--tab-2"
       className="chakra-tabs__tab-panel css-sjt5nk"
+      data-testid="hds.button-tabs.panels.panel"
       hidden={true}
       id="tabs-:r0:--tabpanel-2"
       role="tabpanel"

--- a/packages/tab/src/__snapshots__/Tabs.spec.tsx.snap
+++ b/packages/tab/src/__snapshots__/Tabs.spec.tsx.snap
@@ -8,7 +8,7 @@ exports[`Snapshot (Tabs) Should match snapshot 1`] = `
   <div
     aria-orientation="horizontal"
     className="chakra-tabs__tablist css-5bpqcm"
-    data-testid="hds.tab.list"
+    data-testid="hds.tabs.tablist"
     onKeyDown={[Function]}
     role="tablist"
   >
@@ -16,7 +16,7 @@ exports[`Snapshot (Tabs) Should match snapshot 1`] = `
       aria-controls="tabs-:r0:--tabpanel--1"
       aria-selected={false}
       className="chakra-tabs__tab css-jid256"
-      data-testid="hds.tab"
+      data-testid="hds.tabs.tab"
       id="tabs-:r0:--tab--1"
       onClick={[Function]}
       onFocus={[Function]}
@@ -29,7 +29,7 @@ exports[`Snapshot (Tabs) Should match snapshot 1`] = `
       >
         <p
           className="chakra-text css-epvm6"
-          data-testid="hds.tab.label"
+          data-testid="hds.tabs.tab.label"
         >
           One
         </p>
@@ -39,7 +39,7 @@ exports[`Snapshot (Tabs) Should match snapshot 1`] = `
       aria-controls="tabs-:r0:--tabpanel--1"
       aria-selected={false}
       className="chakra-tabs__tab css-jid256"
-      data-testid="hds.tab"
+      data-testid="hds.tabs.tab"
       id="tabs-:r0:--tab--1"
       onClick={[Function]}
       onFocus={[Function]}
@@ -52,7 +52,7 @@ exports[`Snapshot (Tabs) Should match snapshot 1`] = `
       >
         <p
           className="chakra-text css-epvm6"
-          data-testid="hds.tab.label"
+          data-testid="hds.tabs.tab.label"
         >
           Two
         </p>
@@ -62,7 +62,7 @@ exports[`Snapshot (Tabs) Should match snapshot 1`] = `
       aria-controls="tabs-:r0:--tabpanel--1"
       aria-selected={false}
       className="chakra-tabs__tab css-jid256"
-      data-testid="hds.tab"
+      data-testid="hds.tabs.tab"
       id="tabs-:r0:--tab--1"
       onClick={[Function]}
       onFocus={[Function]}
@@ -75,7 +75,7 @@ exports[`Snapshot (Tabs) Should match snapshot 1`] = `
       >
         <p
           className="chakra-text css-epvm6"
-          data-testid="hds.tab.label"
+          data-testid="hds.tabs.tab.label"
         >
           Three
         </p>
@@ -84,12 +84,12 @@ exports[`Snapshot (Tabs) Should match snapshot 1`] = `
   </div>
   <div
     className="chakra-tabs__tab-panels css-j1h17a"
-    data-testid="hds.tab.panels"
+    data-testid="hds.tabs.panels"
   >
     <div
       aria-labelledby="tabs-:r0:--tab-0"
       className="chakra-tabs__tab-panel css-sjt5nk"
-      data-testid="hds.tab.panels"
+      data-testid="hds.tabs.panels.panel"
       hidden={false}
       id="tabs-:r0:--tabpanel-0"
       role="tabpanel"
@@ -102,7 +102,7 @@ exports[`Snapshot (Tabs) Should match snapshot 1`] = `
     <div
       aria-labelledby="tabs-:r0:--tab-1"
       className="chakra-tabs__tab-panel css-sjt5nk"
-      data-testid="hds.tab.panels"
+      data-testid="hds.tabs.panels.panel"
       hidden={true}
       id="tabs-:r0:--tabpanel-1"
       role="tabpanel"
@@ -111,7 +111,7 @@ exports[`Snapshot (Tabs) Should match snapshot 1`] = `
     <div
       aria-labelledby="tabs-:r0:--tab-2"
       className="chakra-tabs__tab-panel css-sjt5nk"
-      data-testid="hds.tab.panels"
+      data-testid="hds.tabs.panels.panel"
       hidden={true}
       id="tabs-:r0:--tabpanel-2"
       role="tabpanel"

--- a/packages/tab/src/__snapshots__/Tabs.spec.tsx.snap
+++ b/packages/tab/src/__snapshots__/Tabs.spec.tsx.snap
@@ -83,12 +83,12 @@ exports[`Snapshot (Tabs) Should match snapshot 1`] = `
     </button>
   </div>
   <div
-    className="chakra-tabs__tab-panels css-j1h17a"
+    className="chakra-tabs__tab-panels css-j0hrwt"
     data-testid="hds.tabs.panels"
   >
     <div
       aria-labelledby="tabs-:r0:--tab-0"
-      className="chakra-tabs__tab-panel css-sjt5nk"
+      className="chakra-tabs__tab-panel css-47dblg"
       data-testid="hds.tabs.panels.panel"
       hidden={false}
       id="tabs-:r0:--tabpanel-0"
@@ -101,7 +101,7 @@ exports[`Snapshot (Tabs) Should match snapshot 1`] = `
     </div>
     <div
       aria-labelledby="tabs-:r0:--tab-1"
-      className="chakra-tabs__tab-panel css-sjt5nk"
+      className="chakra-tabs__tab-panel css-47dblg"
       data-testid="hds.tabs.panels.panel"
       hidden={true}
       id="tabs-:r0:--tabpanel-1"
@@ -110,7 +110,7 @@ exports[`Snapshot (Tabs) Should match snapshot 1`] = `
     />
     <div
       aria-labelledby="tabs-:r0:--tab-2"
-      className="chakra-tabs__tab-panel css-sjt5nk"
+      className="chakra-tabs__tab-panel css-47dblg"
       data-testid="hds.tabs.panels.panel"
       hidden={true}
       id="tabs-:r0:--tabpanel-2"


### PR DESCRIPTION
PS. It's hard to test the component rn with the existing `test-id`'s especially for `Tabs` nested with `ButtonTabs` or vice-versa. Also, removed the panels padding as these should be set outside or on `render`