### PR TITLE
allow controlled datepicker

### DIFF
--- a/packages/date-picker/src/DatePicker/RangeDatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/RangeDatePicker.tsx
@@ -321,7 +321,7 @@ function Calendar({ baseDate, onSelect = noop, onNext, onPrev }: CalendarProps) 
                           isPlaceholder,
                           isWithinRange,
                         })}
-                        data-testid="hds.datepicker.calendar.date"
+                        data-testid={`hds.datepicker.calendar.date.${value.toDateString()}`}
                       >
                         {value.getDate()}
                       </chakra.button>

--- a/packages/date-picker/src/DatePicker/RangeDatePicker.tsx
+++ b/packages/date-picker/src/DatePicker/RangeDatePicker.tsx
@@ -1,6 +1,6 @@
 import { chakra } from '@chakra-ui/react';
 import { Button } from '@highoutput/hds-forms';
-import { addMonths, format, subMonths } from 'date-fns';
+import { addMonths, endOfDay, format, startOfDay, subMonths } from 'date-fns';
 import * as React from 'react';
 import { invariant } from 'shared/utils';
 import { v4 as uuid } from 'uuid';
@@ -10,36 +10,26 @@ import { DateRange, TimeAdverbial } from '../types';
 import { getDateRangeByTimeAdverbial, getRangeCalendar, noop } from '../utils';
 import { DatePickerControl } from './DatePickerControl';
 import {
+  RangeDatePickerProvider,
   useRangeDatePickerContext,
-  withRangeDatePickerContext,
 } from './RangeDatePickerProvider';
 
 export type RangeDatePickerProps = {
-  /**
-   *
-   * Not implemented yet
-   *
-   */
+  value?: DateRange;
   events?: Date[];
   onApply?(value: DateRange): void;
   onCancel?(currentValue: Partial<DateRange>): void;
-  defaultValue?: DateRange;
   hasTimeAdverbial?: boolean;
   includePreviousMonth?: boolean;
 };
 
-export const RangeDatePicker = withRangeDatePickerContext(function RangeDatePicker({
+function RangeDatePickerInternal({
   onApply,
   onCancel,
-  defaultValue,
   hasTimeAdverbial = true,
   includePreviousMonth = true,
 }: RangeDatePickerProps) {
   const context = useRangeDatePickerContext();
-
-  React.useEffect(() => {
-    if (defaultValue) context.updateSelectedRangeHard(defaultValue);
-  }, [context, defaultValue]);
 
   return (
     <chakra.div
@@ -81,7 +71,15 @@ export const RangeDatePicker = withRangeDatePickerContext(function RangeDatePick
                 variant="outline"
                 accent="gray"
                 onClick={() => {
-                  onCancel?.(context.dateRange);
+                  onCancel?.({
+                    start: context.dateRange.start
+                      ? startOfDay(context.dateRange.start)
+                      : undefined,
+                    until: context.dateRange.until
+                      ? endOfDay(context.dateRange.until)
+                      : undefined,
+                  });
+
                   context.reset();
                 }}
               >
@@ -96,8 +94,8 @@ export const RangeDatePicker = withRangeDatePickerContext(function RangeDatePick
 
                   context.reset();
                   onApply?.({
-                    start,
-                    until,
+                    start: startOfDay(start),
+                    until: endOfDay(until),
                   });
                 }}
               >
@@ -109,7 +107,7 @@ export const RangeDatePicker = withRangeDatePickerContext(function RangeDatePick
       </chakra.div>
     </chakra.div>
   );
-});
+}
 
 function TimeAdverbialMenu() {
   const context = useRangeDatePickerContext();
@@ -338,3 +336,11 @@ function Calendar({ baseDate, onSelect = noop, onNext, onPrev }: CalendarProps) 
     </chakra.div>
   );
 }
+
+export const RangeDatePicker = (props: RangeDatePickerProps) => {
+  return (
+    <RangeDatePickerProvider value={props.value}>
+      <RangeDatePickerInternal {...props} />
+    </RangeDatePickerProvider>
+  );
+};

--- a/packages/date-picker/src/DatePicker/RangeDatePickerProvider.tsx
+++ b/packages/date-picker/src/DatePicker/RangeDatePickerProvider.tsx
@@ -39,9 +39,16 @@ const RangeDatePickerContext = React.createContext<RangeDatePickerState>({
   reset: noop,
 });
 
-function RangeDatePickerProvider({ children }: React.PropsWithChildren) {
-  const [selectedRangeStart, setSelectedRangeStart] = React.useState<Date | undefined>();
-  const [selectedRangeUntil, setSelectedRangeUntil] = React.useState<Date | undefined>();
+type RangeDatePickerProps = React.PropsWithChildren<{
+  value?: DateRange;
+}>;
+
+export function RangeDatePickerProvider({
+  value,
+  children,
+}: React.PropsWithChildren<RangeDatePickerProps>) {
+  const [selectedRangeStart, setSelectedRangeStart] = React.useState(value?.start);
+  const [selectedRangeUntil, setSelectedRangeUntil] = React.useState(value?.until);
 
   const [lastUpdated, setLastUpdated] = React.useState<LastUpdated | undefined>();
   const [currentDate, setCurrentDate] = React.useState(new Date());
@@ -118,16 +125,4 @@ function RangeDatePickerProvider({ children }: React.PropsWithChildren) {
 
 export function useRangeDatePickerContext() {
   return React.useContext(RangeDatePickerContext);
-}
-
-export function withRangeDatePickerContext<T extends Record<string, any>>(
-  Component: (props: T) => JSX.Element,
-) {
-  return function Wrapped(props: T) {
-    return (
-      <RangeDatePickerProvider>
-        <Component {...props} />
-      </RangeDatePickerProvider>
-    );
-  };
 }

--- a/packages/date-picker/src/DatePickerDropdown/RangeDatePickerDropdown.tsx
+++ b/packages/date-picker/src/DatePickerDropdown/RangeDatePickerDropdown.tsx
@@ -4,6 +4,7 @@ import {
   flip,
   FloatingPortal,
   offset,
+  shift,
   useDismiss,
   useFloating,
   useInteractions,
@@ -36,7 +37,13 @@ export function RangeDatePickerDropdown({
     strategy: 'fixed',
     placement: 'bottom-start',
     whileElementsMounted: autoUpdate,
-    middleware: [flip(), offset(8)],
+    middleware: [
+      offset(4),
+      flip(),
+      shift({
+        padding: 6,
+      }),
+    ],
   });
 
   const { isMounted, styles } = useTransitionStyles(context, {

--- a/packages/date-picker/src/DatePickerInput/ClearButton.tsx
+++ b/packages/date-picker/src/DatePickerInput/ClearButton.tsx
@@ -8,6 +8,7 @@ export const ClearButton = React.forwardRef<
 >(function ClearButton(props, ref) {
   return (
     <chakra.button
+      type="button"
       ref={ref}
       height={5}
       width={5}

--- a/packages/date-picker/src/DatePickerInput/DatePickerInput.tsx
+++ b/packages/date-picker/src/DatePickerInput/DatePickerInput.tsx
@@ -3,6 +3,8 @@ import {
   autoUpdate,
   flip,
   FloatingPortal,
+  offset,
+  shift,
   useDismiss,
   useFloating,
   useInteractions,
@@ -53,7 +55,13 @@ const DatePickerInput$ = function DatePickerInput(
     strategy: 'fixed',
     placement: 'bottom-start',
     whileElementsMounted: autoUpdate,
-    middleware: [flip()],
+    middleware: [
+      offset(4),
+      flip(),
+      shift({
+        padding: 6,
+      }),
+    ],
   });
 
   const fieldRef = useMergeRefs([ref, refs.setReference]);
@@ -89,6 +97,7 @@ const DatePickerInput$ = function DatePickerInput(
             id={id}
             ref={fieldRef}
             size={size}
+            type="button"
             onClick={onToggle}
             sx={{
               ...(size === 'sm' && { h: '40px', py: '8px', px: '12px' }),

--- a/packages/date-picker/src/DatePickerInput/DatePickerInput.tsx
+++ b/packages/date-picker/src/DatePickerInput/DatePickerInput.tsx
@@ -27,6 +27,7 @@ export type DatePickerInputProps = FormGroupProps & {
   onChange?(newValue: Date): void;
   placeholder?: string;
   dateFormat?: ((value: Date) => string) | string;
+  __fieldTestId?: string;
 };
 
 const DatePickerInput$ = function DatePickerInput(
@@ -37,6 +38,7 @@ const DatePickerInput$ = function DatePickerInput(
     dateFormat,
     placeholder,
     zIndex = 'modal',
+    __fieldTestId = 'hds.datepicker-input',
     ...formGroupProps
   }: DatePickerInputProps,
   ref: React.ForwardedRef<HTMLButtonElement>,
@@ -116,7 +118,7 @@ const DatePickerInput$ = function DatePickerInput(
               ...(isOpen && {
                 'data-active': true,
               }),
-              'data-testid': 'hds.datepicker-input',
+              'data-testid': __fieldTestId,
             }}
             {...getReferenceProps()}
           >

--- a/packages/date-picker/src/DatePickerInput/RangeDatePickerInput.tsx
+++ b/packages/date-picker/src/DatePickerInput/RangeDatePickerInput.tsx
@@ -32,6 +32,7 @@ export type RangeDatePickerInputProps = FormGroupProps & {
   onChange?(newValue?: Value): void;
   dateFormat?: ((value?: Value) => string) | string;
   placeholder?: string;
+  __fieldTestId?: string;
 };
 
 export const RangeDatePickerInput$ = function RangeDatePickerInput(
@@ -42,6 +43,7 @@ export const RangeDatePickerInput$ = function RangeDatePickerInput(
     dateFormat,
     placeholder,
     zIndex = 'modal',
+    __fieldTestId = 'hds.range-datepicker-input',
     ...formGroupProps
   }: RangeDatePickerInputProps,
   ref: React.ForwardedRef<HTMLButtonElement>,
@@ -131,7 +133,7 @@ export const RangeDatePickerInput$ = function RangeDatePickerInput(
               ...(isOpen && {
                 'data-active': true,
               }),
-              'data-testid': 'hds.datepicker-input',
+              'data-testid': __fieldTestId,
             }}
             {...getReferenceProps()}
           >

--- a/packages/date-picker/src/DatePickerInput/RangeDatePickerInput.tsx
+++ b/packages/date-picker/src/DatePickerInput/RangeDatePickerInput.tsx
@@ -2,6 +2,8 @@ import { Box, chakra, Icon, useDisclosure } from '@chakra-ui/react';
 import {
   autoUpdate,
   flip,
+  offset,
+  shift,
   useDismiss,
   useFloating,
   useInteractions,
@@ -39,7 +41,7 @@ export const RangeDatePickerInput$ = function RangeDatePickerInput(
     onChange = noop,
     dateFormat,
     placeholder,
-    zIndex = 1,
+    zIndex = 'modal',
     ...formGroupProps
   }: RangeDatePickerInputProps,
   ref: React.ForwardedRef<HTMLButtonElement>,
@@ -58,7 +60,13 @@ export const RangeDatePickerInput$ = function RangeDatePickerInput(
     strategy: 'fixed',
     placement: 'bottom-start',
     whileElementsMounted: autoUpdate,
-    middleware: [flip()],
+    middleware: [
+      offset(4),
+      flip(),
+      shift({
+        padding: 6,
+      }),
+    ],
   });
 
   const fieldRef = useMergeRefs([ref, refs.setReference]);
@@ -104,6 +112,7 @@ export const RangeDatePickerInput$ = function RangeDatePickerInput(
             id={id}
             ref={fieldRef}
             size={size}
+            type="button"
             onClick={onToggle}
             sx={{
               ...(size === 'sm' && { h: '40px', py: '8px', px: '12px' }),

--- a/packages/examples/nextjs/pages/index.tsx
+++ b/packages/examples/nextjs/pages/index.tsx
@@ -205,7 +205,7 @@ function Index({ users }: Props) {
             <Box flexGrow={1} />
 
             <HStack spacing={3}>
-              <RangeDatePickerDropdown onApply={setDateRange}>
+              <RangeDatePickerDropdown value={dateRange} onApply={setDateRange}>
                 {({ onToggle }) => (
                   <Button accent="gray" variant="outline" onClick={onToggle}>
                     {dateRange

--- a/packages/forms/src/ComboboxField/ComboboxField.tsx
+++ b/packages/forms/src/ComboboxField/ComboboxField.tsx
@@ -3,6 +3,8 @@ import {
   autoUpdate,
   flip,
   FloatingPortal,
+  offset,
+  shift,
   size as floatingSize,
   useFloating,
 } from '@floating-ui/react';
@@ -138,7 +140,11 @@ function ComboboxField<T extends Option>(
     placement: 'bottom-start',
     whileElementsMounted: autoUpdate,
     middleware: [
+      offset(4),
       flip(),
+      shift({
+        padding: 6,
+      }),
       floatingSize({
         apply({ rects, elements }) {
           Object.assign(elements.floating.style, {

--- a/packages/forms/src/SelectField/SelectField.tsx
+++ b/packages/forms/src/SelectField/SelectField.tsx
@@ -3,6 +3,8 @@ import {
   autoUpdate,
   flip,
   FloatingPortal,
+  offset,
+  shift,
   size as floatingSize,
   useFloating,
 } from '@floating-ui/react';
@@ -97,7 +99,11 @@ function SelectField<T extends Option>(
     placement: 'bottom-start',
     whileElementsMounted: autoUpdate,
     middleware: [
+      offset(4),
       flip(),
+      shift({
+        padding: 6,
+      }),
       floatingSize({
         apply({ rects, elements }) {
           Object.assign(elements.floating.style, {
@@ -114,6 +120,7 @@ function SelectField<T extends Option>(
         <chakra.div>
           <chakra.button
             ref={ref}
+            type="button"
             sx={{
               ...styles.field,
               width: 'full',

--- a/packages/modal/src/Modal.tsx
+++ b/packages/modal/src/Modal.tsx
@@ -171,6 +171,7 @@ export function Modal(props: ModalProps) {
               <Flex
                 sx={{
                   gap: '24px',
+                  flexGrow: 1,
 
                   ...(isSmall && {
                     justifyContent: 'space-between',

--- a/packages/stories/src/forms/RangeSlider.stories.tsx
+++ b/packages/stories/src/forms/RangeSlider.stories.tsx
@@ -1,4 +1,3 @@
-import { Box } from '@chakra-ui/react';
 import { ThemeProvider } from '@highoutput/hds';
 import { RangeSlider } from '@highoutput/hds-forms';
 import { Meta, StoryFn } from '@storybook/react';
@@ -11,9 +10,7 @@ const Story: Meta<typeof RangeSlider> = {
 const Template: StoryFn<typeof RangeSlider> = (args) => {
   return (
     <ThemeProvider>
-      <Box py={16} px={8}>
-        <RangeSlider {...args} />
-      </Box>
+      <RangeSlider {...args} />
     </ThemeProvider>
   );
 };


### PR DESCRIPTION
- allow `RangeDatePicker` to be controlled
- better returned range using `startOfDay` and `endOfDay`
- ensure psuedo inputs (button) are of type button so forms don't submit upon clicks
- utilize `offset, shift` middlewares